### PR TITLE
Store & remove correct class in PresenterHolder

### DIFF
--- a/app/src/main/java/com/israelferrer/effectiveandroid/ui/activities/TopArticleListActivity.java
+++ b/app/src/main/java/com/israelferrer/effectiveandroid/ui/activities/TopArticleListActivity.java
@@ -66,14 +66,14 @@ public class TopArticleListActivity extends EffectiveActivity implements Recycle
     @Override
     protected void onSaveInstanceState(Bundle bundle) {
         presenter.setView(null);
-        PresenterHolder.getInstance().putPresenter(TopArticleListActivity.class, presenter);
+        PresenterHolder.getInstance().putPresenter(TopArticleListPresenter.class, presenter);
     }
 
     @Override
     protected void onDestroy() {
         super.onDestroy();
         if (this.isFinishing()) {
-            PresenterHolder.getInstance().remove(TopArticleListActivity.class);
+            PresenterHolder.getInstance().remove(TopArticleListPresenter.class);
         }
     }
 


### PR DESCRIPTION
The current TopArticleListActivity is storing its own class as the key for its presenter, and getting its presenter with the presenter's class as the key. This will cause the presenter to be recreated during every config change.

This change uses the presenter class consistently as the key.
